### PR TITLE
Remove Dependency on package.json "build" Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Deploy react app to github pages
-      uses: tanwanimohit/deploy-react-to-ghpages@v1.0.1
+      uses: tanwanimohit/deploy-react-to-ghpages@v1.0.2
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
     - run : npm ci
       shell: bash
-    - run : npm run build
+    - run : npx react-scripts build
       shell: bash
     - run : git config user.name github-actions
       shell: bash


### PR DESCRIPTION
## Description

Previously, there was a step that ran `npm run build`, but this assumes that the consumer has a `build` script in their package.json. While this is usually a same assumption since many people start off using create-react-app which initializes the package.json with the `build` script, some consumers may change the name of that script.

With this commit, the step is no longer running an npm script but, instead, uses npx to run the react-scripts package directly to invoke the react-script build script. With this change, consumers do not need to keep the build script configured in their package.json. Of course, even if they do continue to have that script, this change will still work for those consumers passively.

## Testing 

I tested this by pushing my fork's branch (https://github.com/atb-brown/deploy-react-to-ghpages/commit/9afaf230b36c45a3bf2a896bcd4750536334ad0c) and then including it in my project's deployment action - https://github.com/atb-brown/austin/commit/1fac733a59bcf4cf7ba799719b07147791ccef3b

Then, with my changes, I noticed that it worked because the `pages-build-deployment` action kicked off and succeeded:
https://github.com/atb-brown/austin/actions/runs/4586446808
![image](https://user-images.githubusercontent.com/6782887/229327748-731489d2-690b-43cf-a1d3-9fb2b8be5798.png)

And then the visual change that I made showed up (normal the React logo is in the top left corner):
![image](https://user-images.githubusercontent.com/6782887/229327806-ca437b40-c2d2-432c-b9e7-b9ee2bdcf930.png)